### PR TITLE
FIX Allow running on local machines without global PHPUnit install

### DIFF
--- a/code/PhingPHPUnit3ResultFormatter.php
+++ b/code/PhingPHPUnit3ResultFormatter.php
@@ -19,7 +19,9 @@
  * <http://phing.info>.
  */
 
-require_once 'PHPUnit/Framework/TestListener.php';
+if (file_exists('PHPUnit/Framework/TestListener.php')) {
+	require_once 'PHPUnit/Framework/TestListener.php';
+}
 
 /**
  * This abstract class describes classes that format the results of a PHPUnit2 testrun.

--- a/code/PhingXMLPHPUnit3ResultFormatter.php
+++ b/code/PhingXMLPHPUnit3ResultFormatter.php
@@ -19,7 +19,9 @@
  * <http://phing.info>.
  */
 
-require_once 'PHPUnit/Util/Log/JUnit.php';
+if (file_exists('PHPUnit/Util/Log/JUnit.php')) {
+	require_once 'PHPUnit/Util/Log/JUnit.php';
+}
 
 /**
  * Prints XML output of the test to a specified Writer
@@ -85,6 +87,18 @@ class PhingXMLPHPUnit3ResultFormatter extends PhingPHPUnit3ResultFormatter
 		parent::addError($test, $e, $time);
 
 		$this->logger->addError($test, $e, $time);
+	}
+
+	/**
+	 * Risky test.
+	 *
+	 * @param PHPUnit_Framework_Test $test
+	 * @param Exception              $e
+	 * @param float                  $time
+	 * @since  Method available since Release 3.8.0
+	 */
+	function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
+		// Stub out to support PHPUnit 3.8
 	}
 
 	function addFailure(PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)


### PR DESCRIPTION
FIX, Errors occurred when running tests locally (couldn't find PHPUnit files) and 1 missing abstract method addRiskyTest.
