### PR TITLE
fix(composer): Require phpunit ^5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
 	],
 	"require": {
 		"silverstripe/framework": "~4.0",
-		"codeception/codeception": "~2.3"
+		"codeception/codeception": "~2.3",
+		"phpunit/phpunit": "^5.7"
 	},
 	"extra": {
 		"installer-name": "test-assist",


### PR DESCRIPTION
Versions >= 6.0 break compatibility with all versions of silverstripe/framework.

Resolves https://github.com/symbiote/silverstripe-test-assist/issues/17